### PR TITLE
Fix column name for plotting data

### DIFF
--- a/03_Intro_to_GIS.ipynb
+++ b/03_Intro_to_GIS.ipynb
@@ -414,7 +414,7 @@
     "#put another axes to the right of it, at 5% of the total width with 0.1 points of padding in between\n",
     "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.1) \n",
     "# note that you have to specify both ax and cax as arguments for it to work\n",
-    "data.plot(figsize=(10,5), alpha=0.6, column='area', \n",
+    "data.plot(figsize=(10,5), alpha=0.6, column='shape_Area', \n",
     "          legend=True, ax=ax, cax=cax)"
    ]
   },


### PR DESCRIPTION
First thing first, many thanks for releasing these notebooks to the public. I am working on an introductory workshop on spatial analysis with Python and find the materials extremely useful.

Anyway, I ran the cell below and it throws an error. 

```python
from mpl_toolkits.axes_grid1 import make_axes_locatable
fig, ax = plt.subplots(1, 1)
divider = make_axes_locatable(ax) #makes it so you can append to the axes

#put another axes to the right of it, at 5% of the total width with 0.1 points of padding in between
cax = divider.append_axes("right", size="5%", pad=0.1) 
# note that you have to specify both ax and cax as arguments for it to work
data.plot(figsize=(10,5), alpha=0.6, column='area', 
          legend=True, ax=ax, cax=cax)
```

<details>
    <summary>Full Error Message</summary>
    
    ```
    ---------------------------------------------------------------------------
    KeyError                                  Traceback (most recent call last)
    /usr/local/lib/python3.7/dist-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
       2897             try:
    -> 2898                 return self._engine.get_loc(casted_key)
       2899             except KeyError as err:
    
    pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()
    
    pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()
    
    pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()
    
    pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()
    
    KeyError: 'area'
    
    The above exception was the direct cause of the following exception:
    
    KeyError                                  Traceback (most recent call last)
    5 frames
    /usr/local/lib/python3.7/dist-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
       2898                 return self._engine.get_loc(casted_key)
       2899             except KeyError as err:
    -> 2900                 raise KeyError(key) from err
       2901 
       2902         if tolerance is not None:
    
    KeyError: 'area'
    ```

</details>

What I understand is that this cell aims to symbolise the polygons using their area, which is the same as the previous cell. If that is the case, `column='area'` is meant to be `column='shape_Area'`.